### PR TITLE
fix(flaresolverr): raise memory and shm to stop Chromium OOM/crashes

### DIFF
--- a/apps/templates/app-flaresolverr.yaml
+++ b/apps/templates/app-flaresolverr.yaml
@@ -33,11 +33,14 @@ spec:
               value: Europe/Amsterdam
           resources:
             requests:
-              cpu: 200m
-              memory: 512Mi
-            limits:
-              cpu: 1000m
+              cpu: 500m
               memory: 1Gi
+            # Headless Chromium solving Cloudflare challenges is memory- and CPU-hungry;
+            # the previous 1Gi limit / 256Mi shm caused OOM restarts and
+            # "session not created: chrome not reachable" crashes under load.
+            limits:
+              cpu: "2"
+              memory: 3Gi
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
@@ -45,7 +48,7 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
-            sizeLimit: 256Mi
+            sizeLimit: 1Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Headless Chromium solving Cloudflare challenges was hitting the 1Gi memory limit and 256Mi `/dev/shm`, causing OOM restarts (exit 255) and intermittent `session not created: chrome not reachable` errors under scraper load.

- limits: cpu `1`->`2`, memory `1Gi`->`3Gi`
- requests: cpu `200m`->`500m`, memory `512Mi`->`1Gi`
- `/dev/shm`: `256Mi`->`1Gi`

Validated with `helm template`. Pairs with the scraper-side timeout fix (pokemon-bot MR !5).