### PR TITLE
fix(home-assistant): pin ConBee hostPath to CharDevice

### DIFF
--- a/apps/templates/helm-homeassistant.yaml
+++ b/apps/templates/helm-homeassistant.yaml
@@ -42,6 +42,11 @@ spec:
           - name: conbee-usb
             hostPath:
               path: /dev/ttyACM0
+              # CharDevice makes kubelet require an existing character device and
+              # refuse to create a placeholder directory when the node is absent.
+              # Without this, a pod start while the ConBee is unplugged leaves an
+              # empty dir at /dev/ttyACM0 that shadows the real serial node.
+              type: CharDevice
         additionalMounts:
           - name: conbee-usb
             mountPath: /dev/ttyACM0


### PR DESCRIPTION
## What

Adds `type: CharDevice` to the `conbee-usb` `hostPath` volume in the Home Assistant chart values.

## Why

After moving the ConBee II Zigbee dongle to a different USB slot, Home Assistant lost access to it. Root cause: the `hostPath` had no `type`, so when the HA pod started while the device node wasn't present, kubelet created an **empty directory** placeholder at `/dev/ttyACM0` on `homelab-0`. That directory then shadowed the real serial node the kernel wanted to create, so ZHA could never open the radio — even though `lsusb`/`dmesg` showed the ConBee registered.

`type: CharDevice` makes kubelet **require** an existing character device and refuse to create a placeholder directory, so this cannot recur on a future pod start/reboot while the dongle is briefly absent.

## Note

The live device was already recovered manually (removed the stale directory, re-bound `cdc_acm`, HA restarted and is talking to the dongle). Merging this makes ArgoCD sync the guard into the StatefulSet, which triggers one brief HA pod restart.