### PR TITLE
end-of-year: pull image from GitLab registry, deploy via homelab runner

### DIFF
--- a/apps/templates/app-end-of-year.yaml
+++ b/apps/templates/app-end-of-year.yaml
@@ -5,14 +5,39 @@ metadata:
   labels:
     name: end-of-year
 ---
+# -- RBAC for GitLab runner deploy step ----------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: end-of-year-deployer
+  namespace: end-of-year
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitlab-runner-end-of-year-deploy
+  namespace: end-of-year
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-ci-job
+    namespace: gitlab-runner
+roleRef:
+  kind: Role
+  name: end-of-year-deployer
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: gcr-end-of-year-secret
+  name: gitlab-registry-secret
   namespace: end-of-year
 data:
-  .dockerconfigjson: {{ .Values.gcr.end_of_year | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -35,10 +60,11 @@ spec:
         app: end-of-year
     spec:
       imagePullSecrets:
-        - name: gcr-end-of-year-secret
+        - name: gitlab-registry-secret
       containers:
         - name: end-of-year
-          image: gcr.io/thomvandevin-end-of-year/end-of-year
+          image: registry.gitlab.com/thomvandevin-projects/end-of-year:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           readinessProbe:


### PR DESCRIPTION
Migrates **end-of-year** off Google Artifact Registry. Pulls from the GitLab Container Registry via the shared `gitlab-registry-secret` (`.Values.gitlab.registry`) and adds a `end-of-year-deployer` Role + RoleBinding so the homelab CI runner can restart the deployment.

**Pull secret uses the single shared `gitlab.registry` key** — one `read_registry` PAT covering all projects (see #426 for the consolidation of the existing apps onto the same key). No per-app token needed; just ensure `gitlab.registry` exists in SOPS `apps/secrets.yaml` before merging, or ArgoCD sync fails.

App-side MR: https://gitlab.com/thomvandevin-projects/end-of-year/-/merge_requests/1
After the pod serves the new image, delete the old GCP `thomvandevin-end-of-year` repo to end billing.