### PR TITLE
limitless-tournament-decks: pull image from GitLab registry, deploy via homelab runner

### DIFF
--- a/apps/templates/app-limitless-tournament-decks.yaml
+++ b/apps/templates/app-limitless-tournament-decks.yaml
@@ -5,6 +5,31 @@ metadata:
   labels:
     name: limitless-tournament-decks
 ---
+# -- RBAC for GitLab runner deploy step ----------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: limitless-tournament-decks-deployer
+  namespace: limitless-tournament-decks
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitlab-runner-limitless-tournament-decks-deploy
+  namespace: limitless-tournament-decks
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-ci-job
+    namespace: gitlab-runner
+roleRef:
+  kind: Role
+  name: limitless-tournament-decks-deployer
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -18,10 +43,10 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: gcr-limitless-tournament-decks-secret
+  name: gitlab-registry-secret
   namespace: limitless-tournament-decks
 data:
-  .dockerconfigjson: {{ .Values.gcr.limitless_tournament_decks | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,10 +69,11 @@ spec:
         app: limitless-tournament-decks
     spec:
       imagePullSecrets:
-        - name: gcr-limitless-tournament-decks-secret
+        - name: gitlab-registry-secret
       containers:
         - name: limitless-tournament-decks
-          image: gcr.io/limitless-tournament-decks/limitless-tournament-decks
+          image: registry.gitlab.com/thomvandevin-projects/limitless-tournament-decks:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
Migrates **limitless-tournament-decks** off Google Artifact Registry. Pulls from the GitLab Container Registry via the shared `gitlab-registry-secret` (`.Values.gitlab.registry`) and adds a `limitless-tournament-decks-deployer` Role + RoleBinding so the homelab CI runner can restart the deployment.

**Pull secret uses the single shared `gitlab.registry` key** — one `read_registry` PAT covering all projects (see #426 for the consolidation of the existing apps onto the same key). No per-app token needed; just ensure `gitlab.registry` exists in SOPS `apps/secrets.yaml` before merging, or ArgoCD sync fails.

App-side MR: https://gitlab.com/thomvandevin-projects/limitless-tournament-decks/-/merge_requests/4
After the pod serves the new image, delete the old GCP `limitless-tournament-decks` repo to end billing.