### PR TITLE
swiss-rounds: pull image from GitLab registry, deploy via homelab runner

### DIFF
--- a/apps/templates/app-swiss-rounds.yaml
+++ b/apps/templates/app-swiss-rounds.yaml
@@ -5,14 +5,39 @@ metadata:
   labels:
     name: swiss-rounds
 ---
+# -- RBAC for GitLab runner deploy step ----------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: swiss-rounds-deployer
+  namespace: swiss-rounds
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitlab-runner-swiss-rounds-deploy
+  namespace: swiss-rounds
+subjects:
+  - kind: ServiceAccount
+    name: gitlab-ci-job
+    namespace: gitlab-runner-swiss-rounds
+roleRef:
+  kind: Role
+  name: swiss-rounds-deployer
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: gcr-swiss-rounds-secret
+  name: gitlab-registry-secret
   namespace: swiss-rounds
 data:
-  .dockerconfigjson: {{ .Values.gcr.swiss_rounds | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,10 +55,11 @@ spec:
         app: swiss-rounds
     spec:
       imagePullSecrets:
-        - name: gcr-swiss-rounds-secret
+        - name: gitlab-registry-secret
       containers:
         - name: swiss-rounds
-          image: gcr.io/swiss-rounds/swiss-rounds
+          image: registry.gitlab.com/swiss-rounds/swiss-rounds:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
             - containerPort: 8443


### PR DESCRIPTION
Migrates **swiss-rounds** off Google Artifact Registry. Pulls from the GitLab Container Registry via the shared `gitlab-registry-secret` (`.Values.gitlab.registry`) and adds a `swiss-rounds-deployer` Role + RoleBinding so the homelab CI runner can restart the deployment.

**Pull secret uses the single shared `gitlab.registry` key** — one `read_registry` PAT covering all projects (see #426 for the consolidation of the existing apps onto the same key). No per-app token needed; just ensure `gitlab.registry` exists in SOPS `apps/secrets.yaml` before merging, or ArgoCD sync fails.

**swiss-rounds specifics:** it lives in the standalone `swiss-rounds` group, so its image path is `registry.gitlab.com/swiss-rounds/swiss-rounds` and you must share the `homelab-k3s` runner with that group or the pipeline hangs. (The shared PAT still covers it.)

App-side MR: https://gitlab.com/swiss-rounds/swiss-rounds/-/merge_requests/40
After the pod serves the new image, delete the old GCP `swiss-rounds` repo to end billing.