### PR TITLE
Add shared gitlab.registry pull secret + adopt it everywhere

### DIFF
--- a/apps/secrets.yaml
+++ b/apps/secrets.yaml
@@ -7,6 +7,7 @@ gh:
     token: ENC[AES256_GCM,data:N/3fliAosLMf6YmUUSXeoHIEv0iIMK/I9aO6IF8PokuWlerTaVcwuoR5SjCm3I7XNZYaDKPHfdy9vuT+JhJZhv//Wg+fMm4GIJ4Ds4ZRlWFzoZhQLc1lpTeJqLtJ,iv:TONAQeJAFYFK25JnEVbTmK7Ad74Amg3U2upev/KRjkY=,tag:uqJtKc86QgdpBNOPLQ0ejA==,type:str]
 gitlab:
     runner_token: ENC[AES256_GCM,data:ZFG+vqX319YDVkrbrHvnkCaZIMa0De1fOW8OQzItQxP2ImCVhaCkfkgYoS5PwONupobOut0HYLSUvk9D3n7CNSgRceTJqPW6,iv:jlJap+eBLoQxNdq2lbyFTJ8Kuel5AmxUhJB4j+3U4sA=,tag:gSYVK/dlFsMCcJIZIKFKxQ==,type:str]
+    registry: ENC[AES256_GCM,data:nUktvLzcBswes6tIrR58OfxrcoI6b3Ql7ngdU28ugIG1G6u3vvbSK6sryXS4vr1Bxuw7zRPGA0IZOS/cupupRIBR60ThoqsPEYAUbDkwwe0Oa9STnnPAle/mNrcmYzo/FzhJPfantq26wTRReQukHjMXjo2uveqyDDjT3qLEO4mi1bQarAP+VOZWi8Bwh9o3r5OJ/blg+/GiKi8oN4N9fpIGOrgP+bT9FvsC/Rw57ooxwiYY1c/jEf7tzI6hREF/bWjFpF0OI9n2cRgkCAhgAl5cFQVjiVT9HGKvjVSOP/L3iiyo3ZfYA7sSof7mOBJdiG3qpNAyrOGtXN0LUh23+npdXJOqP/3lB2o3b0c0G5XJt63gh/xtiKJiH+36pbnPTOkjwW9z5ImZycKA9yRzoc0VvQm32v/+Opa3yHI622mfacuA+r+9nQ==,iv:whi2ufA4hTdDCqsI1Eyed1+ZXU+eJtNwl2im8yoa5OU=,tag:51rYTyfFeM8tTByQdzUSVQ==,type:str]
 sharry:
     password: ENC[AES256_GCM,data:gzSqAi5DwkcOrRNq,iv:SxftjqLZNXF1HZYuhoLayG0T8mCHqlOxbkW7LNIWVbs=,tag:kQkvtgyPh7vfl2JySqQt1A==,type:str]
     db_password: ENC[AES256_GCM,data:gT6mheIhZtu14g+c,iv:HfrWTbgvCGFauO0w4/uVjsmjz9KrR+C/cZzIc7+3vHE=,tag:keCrORWlXZ9JgGLbg6hqXA==,type:str]
@@ -69,7 +70,7 @@ sops:
             bNy40pY74L7ELIXs7x2+gkLf+7+dGB0aYT6Gm3W88gByiAy6+dy8jQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13w8ryx3k4ak47n7cfmccyachptt5lr3v97ndfc87ms02x7yj4saqp3qhal
-    lastmodified: "2026-07-17T20:31:00Z"
-    mac: ENC[AES256_GCM,data:0xV/JNd7nyiv1LS2xeaatyfStNO84lp2uLk6SXzWf7TTQjmlVBRrb2ttNAKHhMOCTZNiE+fMmtJkZBfu28B8M55fHYqQunB9xksM12EHfgZIBt5bzTrIwv99s4UWD7asFKLBJMjoG2D1V8yPCBgabVEIhAIqYRcI+IOpRdPf2aA=,iv:iHCKrXA5MZgS2SYevwu61YssJGq/53HKDHbHspz5mhc=,tag:67dVqJMMfvFv0kXg6zZoOw==,type:str]
+    lastmodified: "2026-07-17T21:50:35Z"
+    mac: ENC[AES256_GCM,data:pBvpJHA0WJdhPGo1svl1YvSszRIa4sk4ni2kB6X9PnOy2XnCWc+BxgB5977qH8g0C6T/NZyWF9Ma8zv0uBs5i2yrCPYrXhhmnNn/UzmmUf+VndVTr0LRain+GbyxZq30+hN7xNsi1B8WgpMNQfuC5XI3eFzfOmykQ5znDQusATs=,iv:4gVhEyyOuiXEx9dQa2ioVZpk71tadmvn3MKJUzTP4Y4=,tag:ZMZ7aKun9m7MKtAz4IDWAQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2

--- a/apps/templates/app-closet.yaml
+++ b/apps/templates/app-closet.yaml
@@ -63,7 +63,7 @@ metadata:
   name: gitlab-registry-secret
   namespace: closet
 data:
-  .dockerconfigjson: {{ .Values.closet.gitlab.registry | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 # -- MinIO (object storage for garment photos, used from milestone 05) ---------
 apiVersion: v1

--- a/apps/templates/app-pokemon-ai.yaml
+++ b/apps/templates/app-pokemon-ai.yaml
@@ -61,7 +61,7 @@ metadata:
   name: gitlab-registry-secret
   namespace: pokemon-ai
 data:
-  .dockerconfigjson: {{ .Values.pokemon_ai.registry | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 # -- PostgreSQL (pgvector) ----------------------------------------------------
 apiVersion: apps/v1

--- a/apps/templates/app-pokemon-bot.yaml
+++ b/apps/templates/app-pokemon-bot.yaml
@@ -47,7 +47,7 @@ metadata:
   name: gitlab-registry-secret
   namespace: pokemon-bot
 data:
-  .dockerconfigjson: {{ .Values.pokemon_bot.registry | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 # -- RabbitMQ -----------------------------------------------------------------
 apiVersion: apps/v1

--- a/apps/templates/app-van-mierlo.yaml
+++ b/apps/templates/app-van-mierlo.yaml
@@ -60,7 +60,7 @@ metadata:
   name: gitlab-registry-secret
   namespace: van-mierlo
 data:
-  .dockerconfigjson: {{ .Values.vanmierlo.gitlab.registry | quote }}
+  .dockerconfigjson: {{ .Values.gitlab.registry | quote }}
 ---
 # -- MinIO (object storage for file uploads) -----------------------------------
 apiVersion: v1


### PR DESCRIPTION
Establishes a **single shared registry pull credential** and switches all apps onto it.

**Two commits:**
1. `chore: source all gitlab-registry-secrets from shared .Values.gitlab.registry` — points the four existing GitLab-registry apps (**pokemon-bot, pokemon-ai, closet, van-mierlo**) at `.Values.gitlab.registry`, replacing their per-app keys.
2. `chore: add shared gitlab.registry pull-secret value to SOPS` — adds the actual credential (a `read_registry` PAT as base64 dockerconfigjson) to `apps/secrets.yaml`, verified to grant registry pull across both the `thomvandevin-projects` and `swiss-rounds` groups.

Together with the four migration PRs (#422–#425), **all eight apps** then pull via this one credential.

**Merge this PR FIRST** — it adds `gitlab.registry` and swaps the four *running* apps onto it, so it validates the token immediately. Then the four migration PRs are safe to merge. After everything's green, the old per-app keys (`pokemon_bot.registry`, `pokemon_ai.registry`, `closet.gitlab.registry`, `vanmierlo.gitlab.registry`) are unused and can be deleted from SOPS.

Verified: `sops` re-encrypt preserved `gitlab.runner_token` and all other keys; the value decodes to a valid `registry.gitlab.com` dockerconfigjson.