### PR TITLE
Dedicated GitLab runner for the swiss-rounds group

### DIFF
--- a/apps/secrets.yaml
+++ b/apps/secrets.yaml
@@ -8,6 +8,7 @@ gh:
 gitlab:
     runner_token: ENC[AES256_GCM,data:ZFG+vqX319YDVkrbrHvnkCaZIMa0De1fOW8OQzItQxP2ImCVhaCkfkgYoS5PwONupobOut0HYLSUvk9D3n7CNSgRceTJqPW6,iv:jlJap+eBLoQxNdq2lbyFTJ8Kuel5AmxUhJB4j+3U4sA=,tag:gSYVK/dlFsMCcJIZIKFKxQ==,type:str]
     registry: ENC[AES256_GCM,data:nUktvLzcBswes6tIrR58OfxrcoI6b3Ql7ngdU28ugIG1G6u3vvbSK6sryXS4vr1Bxuw7zRPGA0IZOS/cupupRIBR60ThoqsPEYAUbDkwwe0Oa9STnnPAle/mNrcmYzo/FzhJPfantq26wTRReQukHjMXjo2uveqyDDjT3qLEO4mi1bQarAP+VOZWi8Bwh9o3r5OJ/blg+/GiKi8oN4N9fpIGOrgP+bT9FvsC/Rw57ooxwiYY1c/jEf7tzI6hREF/bWjFpF0OI9n2cRgkCAhgAl5cFQVjiVT9HGKvjVSOP/L3iiyo3ZfYA7sSof7mOBJdiG3qpNAyrOGtXN0LUh23+npdXJOqP/3lB2o3b0c0G5XJt63gh/xtiKJiH+36pbnPTOkjwW9z5ImZycKA9yRzoc0VvQm32v/+Opa3yHI622mfacuA+r+9nQ==,iv:whi2ufA4hTdDCqsI1Eyed1+ZXU+eJtNwl2im8yoa5OU=,tag:51rYTyfFeM8tTByQdzUSVQ==,type:str]
+    swiss_rounds_runner_token: ENC[AES256_GCM,data:1doUq7BvlJGDc8ZLsSh4OdczzYufKVnLweEMJaySRm2yng/CPnxJFG3NajGpTI8Kss1TFtp4qiupF5KD+H7S34wjgkPlZ3ojRp16aNY=,iv:IlGwWZVdMZDD4dwwUOeZQxTCXDPuexVtE4a3OX49jBY=,tag:8otYpEy63nHk2NvfetTlNg==,type:str]
 sharry:
     password: ENC[AES256_GCM,data:gzSqAi5DwkcOrRNq,iv:SxftjqLZNXF1HZYuhoLayG0T8mCHqlOxbkW7LNIWVbs=,tag:kQkvtgyPh7vfl2JySqQt1A==,type:str]
     db_password: ENC[AES256_GCM,data:gT6mheIhZtu14g+c,iv:HfrWTbgvCGFauO0w4/uVjsmjz9KrR+C/cZzIc7+3vHE=,tag:keCrORWlXZ9JgGLbg6hqXA==,type:str]
@@ -64,7 +65,7 @@ sops:
             bNy40pY74L7ELIXs7x2+gkLf+7+dGB0aYT6Gm3W88gByiAy6+dy8jQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age13w8ryx3k4ak47n7cfmccyachptt5lr3v97ndfc87ms02x7yj4saqp3qhal
-    lastmodified: "2026-07-17T22:11:25Z"
-    mac: ENC[AES256_GCM,data:CY5vTBIp/jw0XKPJPRq7PQFkXdNy0Odfmx1tpJrwaUlVTBZ+WQSs/T6RBF7taO4oIE7vZe1XGLaFeOTNrirMR9O/8Ccl4WwBhaRQu+b7XJ6R5RsVPWKvi582JBYaHqbc1PQD3yBfyMmRcDr06XPnkT7p5sNudwM82a+jNhzX7Qw=,iv:Lt4vYcmeXm42GHT1U+pIgMSYLekgD+e7jOy6vC0V7zA=,tag:9+9Bcf9hPsDCfik7bFkzzg==,type:str]
+    lastmodified: "2026-07-18T10:00:30Z"
+    mac: ENC[AES256_GCM,data:j9sUzixHWzO6iydLjjVnAdJnh6jJ32iWw7bcau/+xXfXE0HGd1kWO3ARdbLZlXTQtGn3goGaN3+rn1ONm73J+0uBMxt+dF0nSPr7MvtMvElRN0V1SXyCE9kJJh0yexGoGA0Q0PGUBWZOxVr5GBYtjYSI7YZbAaDgnLpKO25E7c4=,iv:+j6GYeyoGPSxCRZnnxMjWnJtxD6UKbhaeV5gnALr/P8=,tag:7spSdkceMJ9kjpNULaS+MA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.2

--- a/apps/templates/helm-gitlab-runner-swiss-rounds.yaml
+++ b/apps/templates/helm-gitlab-runner-swiss-rounds.yaml
@@ -1,0 +1,64 @@
+# Dedicated GitLab runner for the swiss-rounds group, which is shared with an
+# external collaborator and lives outside thomvandevin-projects (so it can't use
+# the homelab-k3s group runner). Runs on the same cluster but fully isolated:
+# its own namespace, and unprivileged — swiss-rounds only builds with Kaniko, so
+# unlike the main runner it never needs node-level (dind) access.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitlab-runner-swiss-rounds
+  labels:
+    name: gitlab-runner-swiss-rounds
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: gitlab-runner-swiss-rounds-secret
+  namespace: gitlab-runner-swiss-rounds
+data:
+  runner-registration-token: {{ .Values.gitlab.swiss_rounds_runner_token | b64enc | quote }}
+  runner-token: {{ .Values.gitlab.swiss_rounds_runner_token | b64enc | quote }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gitlab-ci-job
+  namespace: gitlab-runner-swiss-rounds
+automountServiceAccountToken: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitlab-runner-swiss-rounds
+  namespace: argocd
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+  source:
+    repoURL: https://charts.gitlab.io
+    chart: gitlab-runner
+    targetRevision: 0.90.1
+    helm:
+      valuesObject:
+        gitlabUrl: https://gitlab.com
+        rbac:
+          create: true
+        runners:
+          secret: gitlab-runner-swiss-rounds-secret
+          tags: "homelab"
+          config: |
+            [[runners]]
+              [runners.kubernetes]
+                namespace = "gitlab-runner-swiss-rounds"
+                image = "ubuntu:22.04"
+                service_account = "gitlab-ci-job"
+                # unprivileged: swiss-rounds builds with Kaniko, not dind
+                privileged = false
+  destination:
+    namespace: gitlab-runner-swiss-rounds
+    server: https://kubernetes.default.svc


### PR DESCRIPTION
Adds a second gitlab-runner on the cluster, registered to the `swiss-rounds` group (shared with an external collaborator, outside `thomvandevin-projects`). Isolated: own namespace `gitlab-runner-swiss-rounds`, **unprivileged** (Kaniko-only, no node access), tagged `homelab`. Runner auth token stored in SOPS as `gitlab.swiss_rounds_runner_token`. Its deploy RBAC (in #425) is scoped to only the swiss-rounds namespace.