### PR TITLE
fix: stop routing decklists admin paths publicly

### DIFF
--- a/apps/templates/cloudflare-tunnel.yaml
+++ b/apps/templates/cloudflare-tunnel.yaml
@@ -61,6 +61,18 @@ spec:
             - hostname: gblock.thomvandev.in
               service: http://showcase-ui.pokemon-ai.svc.cluster.local:80
             # Decklist
+            # /preload and /cleanup are unauthenticated admin routes: one
+            # triggers a full scrape of Limitless, the other deletes cache
+            # rows. They were publicly reachable because this hostname
+            # routes every path.
+            #
+            # The preload and cleanup CronJobs call the service directly
+            # in-cluster, so they never traverse the tunnel and are
+            # unaffected. Must precede the catch-all below -- cloudflared
+            # is first-match.
+            - hostname: decklists.thomvandev.in
+              path: ^/(preload|cleanup)/?$
+              service: http_status:404
             - hostname: decklists.thomvandev.in
               service: http://limitless-tournament-decks-svc.limitless-tournament-decks.svc.cluster.local:80
             # Swiss Rounds


### PR DESCRIPTION
`decklists.thomvandev.in` routes **every path** to the app, so two unauthenticated admin routes were reachable from the public internet:

| Route | Effect |
|---|---|
| `/preload` | Triggers a full scrape of Limitless (`maxDecksPerTournament=-1`) |
| `/cleanup` | Deletes cache rows |

Both confirmed answering **200 publicly**.

## The fix

Returns 404 for those paths at the tunnel, before the catch-all rule for the hostname (cloudflared is first-match).

**The CronJobs are unaffected.** They call `http://limitless-tournament-decks-svc...svc.cluster.local/preload` directly in-cluster, so they never traverse the tunnel. That is why this needs no change to the app or to the CronJob definitions.

## Note before merging

- Auto-sync is on (`automated: {prune: true}`), so this deploys on merge
- `Deployment/swiss-rounds/swiss-rounds-stg` is **already OutOfSync** and will sync too — unrelated to this change, flagging in case that is unexpected

## Related

Companion to the SSRF fix in `limitless-tournament-decks` MR !15, which closed `/image-proxy` fetching arbitrary URLs from the same public hostname.