### PR TITLE
feat(limitless): add CronJobs for officially sanctioned events

### DIFF
--- a/apps/templates/app-limitless-tournament-decks.yaml
+++ b/apps/templates/app-limitless-tournament-decks.yaml
@@ -176,6 +176,76 @@ spec:
                   memory: 128Mi
           restartPolicy: OnFailure
 ---
+# Officially sanctioned events -- Regionals, Internationals, Worlds -- scraped
+# from limitlesstcg.com and onepiece.limitlesstcg.com rather than the play site.
+#
+# Daily rather than 3-hourly: these events run on weekends, so a 3-hourly poll
+# would be almost entirely wasted requests against a source that has rate-limited
+# this project before.
+#
+# eventType defaults to 'community' on the route, so the three jobs above are
+# unaffected by this addition.
+#
+# Each tournament costs exactly two requests regardless of field size, because
+# /tournaments/{id}/decklists returns every list for an event in one response.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: limitless-preload-official-onepiece
+  namespace: limitless-tournament-decks
+spec:
+  schedule: "0 5 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: curl
+              image: curlimages/curl:latest@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+              args:
+                - curl
+                - -X
+                - GET
+                - http://limitless-tournament-decks-svc.limitless-tournament-decks.svc.cluster.local/preload?game=OP&eventType=official&maxTournaments=10
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: limitless-preload-official-pokemon
+  namespace: limitless-tournament-decks
+spec:
+  # An hour after the One Piece job. The app's outbound throttle is a single
+  # global chain, so overlapping runs would serialise against each other anyway.
+  schedule: "0 6 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: curl
+              image: curlimages/curl:latest@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+              args:
+                - curl
+                - -X
+                - GET
+                - http://limitless-tournament-decks-svc.limitless-tournament-decks.svc.cluster.local/preload?game=PTCG&eventType=official&maxTournaments=10
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+          restartPolicy: OnFailure
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:


### PR DESCRIPTION
Companion to [limitless-tournament-decks!24](https://gitlab.com/thomvandevin-projects/limitless-tournament-decks/-/merge_requests/24), already merged and deployed.

The app now also scrapes officially sanctioned in-person events — Regionals,
Internationals, Worlds, Champions League — from `limitlesstcg.com` and
`onepiece.limitlesstcg.com`, alongside the community events from the play site.
These two jobs keep that data fresh.

## Why daily rather than 3-hourly

Official events run on weekends. A 3-hourly poll would be almost entirely wasted
requests against a source that has rate-limited this project before.

Each tournament costs exactly **two** requests regardless of field size, because
`/tournaments/{id}/decklists` returns every list for an event in one response — so
these jobs are far lighter than the community ones despite covering larger events.

The two jobs are staggered an hour apart. The app's outbound throttle is a single
global chain, so overlapping runs would serialise against each other anyway.

## Safety

`eventType` defaults to `community` on the route, so the three existing jobs are
unaffected — no change to their manifests.

`/preload` remains unrouted publicly (the tunnel returns 404); these jobs reach it
through the in-cluster service address, exactly as the existing ones do.

## Validation

`kubectl apply --dry-run=server` against the live cluster:

```
cronjob.batch/limitless-preload-onepiece            configured (server dry run)
cronjob.batch/limitless-preload-pokemon             configured (server dry run)
cronjob.batch/limitless-preload-official-onepiece   created    (server dry run)
cronjob.batch/limitless-preload-official-pokemon    created    (server dry run)
cronjob.batch/limitless-cleanup                     configured (server dry run)
```

Two created, three unchanged.