### PR TITLE
fix(home-assistant): drop deprecated http block from managed config

### DIFF
--- a/apps/templates/helm-homeassistant.yaml
+++ b/apps/templates/helm-homeassistant.yaml
@@ -31,8 +31,21 @@ spec:
         configuration:
           enabled: true
           forceInit: true
-          trusted_proxies:
-            - 10.0.0.0/8 # k8s
+          # Chart default minus the http block: HTTP/trusted_proxies config is
+          # UI-managed (Settings > System > Network) and YAML support is removed in 2027.2.0
+          templateConfig: |-
+            default_config:
+
+            {{- if .Values.serviceMonitor.enabled }}
+            prometheus:
+            {{- end }}
+
+            frontend:
+              themes: !include_dir_merge_named themes
+
+            automation: !include automations.yaml
+            script: !include scripts.yaml
+            scene: !include scenes.yaml
         persistence:
           enabled: true
         hostNetwork: true


### PR DESCRIPTION
Home Assistant warns that `http:` in `configuration.yaml` is deprecated and stops working in 2027.2.0. The settings have already been imported into the UI (Settings > System > Network).

The block comes from the chart: `configuration.templateConfig` emits `http.use_x_forwarded_for` + `trusted_proxies` whenever `ingress.enabled` is true, and `forceInit: true` re-merges it into the PVC on every pod start. Deleting it by hand does not stick.

This overrides `templateConfig` with the chart default minus the `http:` block, and drops the now-unused `trusted_proxies` value. Also drops the leading comment from the template, which `yq`'s merge had been duplicating on every restart (34 copies had accumulated).

The live `/config/configuration.yaml` in the PVC was cleaned separately (backup at `/config/configuration.yaml.pre-http-removal`); the merge only adds keys, so it could not remove the block on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8tKR5ssWRL95KqeUw5Cor