### PR TITLE
fix(home-assistant): drop serviceMonitor conditional from templateConfig

### DIFF
--- a/apps/templates/helm-homeassistant.yaml
+++ b/apps/templates/helm-homeassistant.yaml
@@ -36,10 +36,6 @@ spec:
           templateConfig: |-
             default_config:
 
-            {{- if .Values.serviceMonitor.enabled }}
-            prometheus:
-            {{- end }}
-
             frontend:
               themes: !include_dir_merge_named themes
 


### PR DESCRIPTION
Hotfix for #460. That PR added a `{{- if .Values.serviceMonitor.enabled }}` conditional inside `configuration.templateConfig`, intended for the home-assistant chart's own `tpl` call. But the app-of-apps chart renders this file first, where `.Values.serviceMonitor` is nil, so manifest generation for the entire `apps` application failed:

```
ComparisonError: nil pointer evaluating interface {}.enabled
```

`serviceMonitor` is not enabled for this app, so the conditional was dead weight. Removed rather than escaped.

Verified by rendering the outer chart, not just the inner one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8tKR5ssWRL95KqeUw5Cor