### PR TITLE
feat(matter-server): deploy python-matter-server for Matter over Thread

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matter-server
+  labels:
+    name: matter-server
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: matter-server-data
+  namespace: matter-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matter-server
+  namespace: matter-server
+spec:
+  replicas: 1
+  # RWO volume plus a fixed host port means the old pod must go before the new one starts
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: matter-server
+  template:
+    metadata:
+      labels:
+        app: matter-server
+    spec:
+      # Matter commissioning relies on IPv6 multicast and mDNS reaching the LAN and the
+      # Thread border router, which the pod network cannot carry. It also puts the
+      # websocket on the node, so Home Assistant (also hostNetwork) reaches it on localhost.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: matter-server
+          image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --storage-path
+            - /data
+          ports:
+            - containerPort: 5580
+              name: ws
+          env:
+            - name: TZ
+              value: Europe/Amsterdam
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: matter-server-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matter-server
+  namespace: matter-server
+spec:
+  type: ClusterIP
+  selector:
+    app: matter-server
+  ports:
+    - name: ws
+      port: 5580
+      targetPort: 5580


### PR DESCRIPTION
Adds a Matter Server so Home Assistant can commission and control Matter-over-Thread devices, using the SLZB-MR5U's on-device OpenThread Border Router.

## Why this is needed

The Matter integration normally relies on the `core_matter_server` add-on. Home Assistant runs as a plain container in this cluster, so there are no add-ons and the server has to be deployed ourselves.

## Design notes

- **`hostNetwork: true`** is not optional. Matter commissioning depends on IPv6 multicast and mDNS reaching the LAN and the Thread border router, and the pod network cannot carry that. It also puts the websocket on the node, so Home Assistant (already `hostNetwork`) reaches it at the integration's own default of `ws://localhost:5580/ws` with no extra config.
- **`strategy: Recreate`** because the RWO Longhorn volume and the fixed host port both prevent a new pod starting alongside the old one.
- **Longhorn PVC rather than emptyDir.** `/data` holds the Matter fabric credentials. Losing it means re-commissioning every device.
- Image pinned to `8.1.2`, the current upstream release, so Renovate can track it.

## Verification

- Renders through the outer app-of-apps chart, not just in isolation.
- All four resources pass `kubectl apply --dry-run=server`.
- Port 5580 confirmed free on `homelab-0`.

## After merge

1. Confirm the pod is running and the websocket answers on 5580.
2. Add the Matter integration in HA, accepting the default `ws://localhost:5580/ws`.
3. Commission the Thread bulbs onto the border router at `192.168.178.12`.

Note on commissioning: Matter devices are usually onboarded over Bluetooth. The simplest route is the Home Assistant companion app, which uses the phone's Bluetooth. Commissioning from the server instead would need the host Bluetooth adapter passed in, and HA currently logs `Missing NET_ADMIN/NET_RAW capabilities` for its own Bluetooth, so that path needs work first. Left out deliberately to keep this change minimal.