### PR TITLE
fix: lower idle CPU requests so Longhorn instance-manager can schedule

### DIFF
--- a/apps/templates/app-closet.yaml
+++ b/apps/templates/app-closet.yaml
@@ -245,7 +245,7 @@ spec:
                   key: ai-internal-token
           resources:
             requests:
-              cpu: 250m
+              cpu: 100m
               memory: 512Mi
             limits:
               cpu: "1"

--- a/apps/templates/app-limitless-tournament-decks.yaml
+++ b/apps/templates/app-limitless-tournament-decks.yaml
@@ -100,7 +100,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 384Mi
             limits:
               cpu: 500m

--- a/apps/templates/app-scraper.yaml
+++ b/apps/templates/app-scraper.yaml
@@ -110,7 +110,7 @@ spec:
                   key: token
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 512Mi
             limits:
               cpu: 500m

--- a/apps/templates/app-slowpoke-bingo.yaml
+++ b/apps/templates/app-slowpoke-bingo.yaml
@@ -156,7 +156,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 384Mi
             limits:
               cpu: 500m


### PR DESCRIPTION
Unblocks Longhorn volume provisioning, which is currently broken cluster-wide.

## Root cause

1. Longhorn upgraded to v1.12.1 (#469), making that the default engine image.
2. The matching instance-manager pod needs **480m CPU**.
3. The node had **3766m of 4000m** already requested, leaving ~234m.
4. The pod has been failing `OutOfcpu` every 2 minutes since 03:11 today and has no pod at all (`currentState: error`).
5. No instance-manager means no replicas, so every new PVC faults with `ReplicaSchedulingFailure: none of the node candidates contains a ready engine image`.

This is **not** specific to one app. I confirmed it with a throwaway 1Gi PVC in `default`, which faulted identically. It has been deleted.

Note the node is not busy: actual utilisation is ~28% CPU with load 1.5 on 4 cores. This is purely reservation exhaustion. Kubernetes schedules on requests, not usage.

## The change

Four idle backends trimmed to a 100m floor:

| Pod | Requested | Actually using | Now |
|---|---|---|---|
| closet-server | 250m | 2m | 100m |
| scraper | 200m | 1m | 100m |
| limitless-tournament-decks | 200m | 2m | 100m |
| slowpoke-bingo | 200m | 1m | 100m |

Frees **450m**, leaving ~684m available against the 480m needed.

**Requests only. Every limit is unchanged**, so burst capacity is identical to today. These are floors, not ceilings.

## flaresolverr is deliberately untouched

It is the worst offender on paper, reserving 500m while using 1m. It is excluded anyway, because it is the one workload here with a documented history of resource starvation (see the comment in its manifest about OOM restarts and `chrome not reachable`). Squeezing the one service with known resource sensitivity to fix a reservation problem would be the wrong trade, and there was plenty of genuinely idle reservation elsewhere.

## Follow-up, not included here

Volumes are spread across four engine versions: 5 on v1.9.0, 3 on v1.11.0, 1 on v1.12.0, 1 on v1.12.1. Longhorn keeps the old instance-manager alive to serve them, which is why two managers need 480m each. Upgrading volume engine images would retire the old manager and return 480m, but that is a separate operation and should not ride along with this fix.