### PR TITLE
fix(matter-server): correct image tag to 8.1.0

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -43,7 +43,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: matter-server
-          image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
+          image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
           imagePullPolicy: IfNotPresent
           args:
             - --storage-path


### PR DESCRIPTION
Fixes `ErrImagePull` on the Matter Server deployed in #470.

```
failed to resolve reference "ghcr.io/home-assistant-libs/python-matter-server:8.1.2": not found
```

My mistake in #470: I took `8.1.2` from the GitHub *releases* API and assumed the container tag matched. It does not. That release has no image published to ghcr.io.

Verified against the registry manifest API:

```
tag 8.1.0 -> HTTP 200
tag 8.1.2 -> HTTP 404
```

`8.1.0` is the newest concrete tag actually published. Keeping a pinned version rather than switching to `stable` so Renovate can continue tracking it.

Everything else in the deployment is now healthy: the Longhorn volume is `attached/degraded` (matching the other volumes) after #471 freed the CPU for the instance-manager, and the pod schedules fine. The image tag is the last blocker.