### PR TITLE
fix(longhorn): enable automatic engine upgrades and match replica count to node count

### DIFF
--- a/apps/templates/helm-longhorn.yaml
+++ b/apps/templates/helm-longhorn.yaml
@@ -26,6 +26,14 @@ spec:
             enabled: true
             additionalLabels:
               release: prometheus
+        persistence:
+          # Single-node cluster with replica-soft-anti-affinity off, so replicas 2 and 3
+          # can never be scheduled and every volume sits permanently degraded
+          defaultClassReplicaCount: 1
+        defaultSettings:
+          # Left at the chart default of 0, engines are never upgraded with the manager;
+          # volumes had drifted across four engine versions back to v1.9.0
+          concurrentAutomaticEngineUpgradePerNodeLimit: 1
   destination:
     namespace: longhorn-system
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Fixes the engine version drift found while debugging #471.

## Two root causes

**1. Automatic engine upgrades are disabled.**

`concurrent-automatic-engine-upgrade-per-node-limit` is `0`, the chart default. Per the chart's own docs: *"When the value is 0, Longhorn does not automatically upgrade volume engines to the new default engine image version."*

So every chart bump moved the manager and left volumes behind. Current spread:

| Engine | Volumes |
|---|---|
| v1.9.0 | 5 (prometheus, grafana, home-assistant, registry, postgresql) |
| v1.11.0 | 3 (sharry, rabbitmq, van-mierlo minio) |
| v1.12.0 | 1 (closet minio) |
| v1.12.1 | 1 (matter-server) |

Running v1.9.0 engines under a v1.12.1 manager is far outside Longhorn's supported version skew, so this is a latent risk, not just untidiness.

**2. Replica count does not match the cluster.**

Every volume requests 3 replicas on a single node with `replica-soft-anti-affinity: false`, so replicas 2 and 3 can never be scheduled and all volumes sit permanently `degraded`.

This is not cosmetic. **Longhorn refuses a live engine upgrade on a degraded volume**, so the drift could not self-correct even after enabling upgrades. The two problems are linked, which is why both are fixed here.

Nothing is lost by dropping to 1: only one replica has ever existed. This makes the declared intent match reality.

## Verified

Rendered the chart with these overrides:

```
storageclass.yaml:  numberOfReplicas: "1"
default-setting:    concurrent-automatic-engine-upgrade-per-node-limit: "1"
```

Limit of 1 rather than a higher value so engines upgrade strictly one at a time.

## Manual steps still required after merge

Merging alone will not fix existing volumes. Two things need doing by hand:

**a. Drop existing volumes to 1 replica** so they become healthy and eligible for live upgrade:

```
kubectl get volumes.longhorn.io -n longhorn-system -o name \
  | xargs -I{} kubectl patch {} -n longhorn-system --type=merge \
      -p '{"spec":{"numberOfReplicas":1}}'
```

I could not run this myself, it was blocked by the permission classifier, which seems fair for a bulk storage mutation.

**b. Recreate the StorageClass.** StorageClass `parameters` are immutable, and the `longhorn` SC is created by longhorn-manager from the `longhorn-storageclass` ConfigMap rather than by Helm. This PR updates the ConfigMap, but the live SC keeps `numberOfReplicas: "3"` until it is deleted and recreated:

```
kubectl delete sc longhorn
```

Safe for existing PVs and PVCs, which are already bound and do not consult the SC. Only affects new provisioning, and longhorn-manager recreates it within seconds.

## Expected outcome

Once volumes are healthy, Longhorn live-upgrades them one at a time to v1.12.1. The old v1.12.0 instance-manager then has nothing to serve and retires, returning its **480m CPU reservation**, which is the same pressure that caused #471.