### PR TITLE
feat(gitlab-runner): wire up S3 distributed cache backed by MinIO

### DIFF
--- a/apps/templates/helm-gitlab-runner.yaml
+++ b/apps/templates/helm-gitlab-runner.yaml
@@ -8,6 +8,60 @@ data:
   runner-registration-token: {{ .Values.gitlab.runner_token | b64enc | quote }}
   runner-token: {{ .Values.gitlab.runner_token | b64enc | quote }}
 ---
+# Distribution cache for CI. Reuses the closet MinIO rather than running a second
+# object store; the runner keeps its own bucket, separate from the app's data.
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: gitlab-runner-cache-secret
+  namespace: gitlab-runner
+data:
+  accesskey: {{ .Values.closet.minio.access_key | b64enc | quote }}
+  secretkey: {{ .Values.closet.minio.secret_key | b64enc | quote }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gitlab-runner-cache-bucket
+  namespace: gitlab-runner
+  annotations:
+    # The runner never creates the bucket itself, and a plain Job would be immutable
+    # across syncs, so run it as a self-deleting hook
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          command: ["sh", "-c"]
+          args:
+            - |
+              mc alias set minio http://minio-svc.closet.svc.cluster.local:9000 "$ACCESS_KEY" "$SECRET_KEY"
+              mc mb --ignore-existing minio/gitlab-runner-cache
+          env:
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-runner-cache-secret
+                  key: accesskey
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: gitlab-runner-cache-secret
+                  key: secretkey
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -39,6 +93,8 @@ spec:
         runners:
           secret: gitlab-runner-secret
           tags: "homelab"
+          cache:
+            secretName: gitlab-runner-cache-secret
           config: |
             [[runners]]
               [runners.kubernetes]
@@ -49,6 +105,16 @@ spec:
                 # Testcontainers test jobs (all CI moved off gitlab.com
                 # shared runners to stay within compute minutes)
                 privileged = true
+              [runners.cache]
+                Type = "s3"
+                Path = "gitlab-runner"
+                Shared = true
+                [runners.cache.s3]
+                  ServerAddress = "minio-svc.closet.svc.cluster.local:9000"
+                  BucketName = "gitlab-runner-cache"
+                  BucketLocation = "us-east-1"
+                  # in-cluster MinIO speaks plain HTTP
+                  Insecure = true
   destination:
     namespace: gitlab-runner
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Fixes CI caching, which has been silently broken.

## Problem

The runner config has `[runners.kubernetes]` but no `[runners.cache]`, so any job declaring `cache:` fails:

```
ERROR: Could not create cache adapter
  error=cache factory not found: factory for cache adapter ... not registered
```

72 occurrences in the current runner log. Nothing fails visibly, jobs just re-download dependencies every run. It is a quiet tax on every pipeline, most noticeably on the closet dind builds.

## Approach

Points the cache at the **existing closet MinIO** with its own `gitlab-runner-cache` bucket, rather than deploying a second object store. The node currently has ~204m of CPU requests free, so avoiding another MinIO (100m request, 256Mi) matters.

The bucket is created by a `mc mb --ignore-existing` Job. It runs as an ArgoCD `PostSync` hook with `hook-delete-policy: HookSucceeded` because the runner never creates the bucket itself, and a plain Job would be immutable across syncs.

## Verified

- Renders through the outer app-of-apps chart.
- All five resources pass `kubectl apply --dry-run=server`.
- Secret key names confirmed against the chart's own entrypoint, which reads `/secrets/accesskey` and `/secrets/secretkey` into `CACHE_S3_ACCESS_KEY` / `CACHE_S3_SECRET_KEY`.

## Tradeoff worth your call

This reuses closet's MinIO **root** credentials (`closet.minio.access_key`/`secret_key`), because those are the only MinIO credentials that exist in SOPS. The cleaner design is a dedicated MinIO user scoped to just the cache bucket, but that needs a new password in `apps/secrets.yaml` and I cannot decrypt or re-encrypt that file.

The exposure is limited: the cache credentials live in the runner's config and are used by the helper container, not the build container, and this runner only serves your own `thomvandevin-projects` group.

**The swiss-rounds runner is deliberately not given these credentials.** That group is shared with an external collaborator, so it keeps no access to closet's object storage.

If you would rather have a scoped user, add something like `closet.minio.ci_access_key` / `ci_secret_key` to SOPS and I will switch this over and extend the hook to create the user and attach a bucket-scoped policy.