### PR TITLE
fix(matter-server): pin primary interface for link-local addressing

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -48,6 +48,11 @@ spec:
           args:
             - --storage-path
             - /data
+            # Without this the SDK logs "Using 'None' as primary interface" and every
+            # mDNS advertisement fails with "No endpoint"; Thread devices are reached
+            # over IPv6 link-local, so it has to be pinned to the LAN interface
+            - --primary-interface
+            - enp1s0
           ports:
             - containerPort: 5580
               name: ws


### PR DESCRIPTION
Fixes Matter commissioning, which currently never completes.

## Symptom

Commissioning an IKEA KAJPLATS (Matter-over-Thread) bulb sits at "adding device" and never succeeds. The Matter Server log shows no commissioning attempt at all, only the client giving up:

```
WARNING [client_handler] Disconnected: No PONG received after 27.5 seconds
```

at 19:19:44 and 19:40:27, matching the two attempts.

## Cause

At startup the SDK reports:

```
INFO  [server] Using 'None' as primary interface (for link-local addresses)
CHIP_ERROR [chip.native.DIS] Failed to advertise records:
  minimal_mdns/Server.cpp:344: CHIP Error 0x00000046: No endpoint
```

That second line repeats hundreds of times. Matter over Thread addresses devices via IPv6 link-local, so the controller needs a primary interface. Under `hostNetwork` the container sees `enp1s0`, `cni0`, `flannel.1` and `tailscale0`, and selects none of them by default, so mDNS has no endpoint to advertise on and discovery cannot complete.

Pinning `--primary-interface enp1s0` gives it the LAN interface explicitly.

## Verified

- Renders through the outer app-of-apps chart.
- Passes `kubectl apply --dry-run=server`.
- `--primary-interface` confirmed against the container's own `matter-server --help`: *"Primary network interface for link-local addresses (optional)."*

## Not addressed here

Commissioning also needs a Bluetooth commissioner. The supported route is the Home Assistant companion app, which uses the phone's radio. The server's own Bluetooth is not usable (HA logs `Missing NET_ADMIN/NET_RAW capabilities`), so `--bluetooth-adapter` is deliberately left off rather than bundling a speculative change.