### PR TITLE
feat(nixos): enable bluetooth for Matter BLE commissioning

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -39,6 +39,13 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Matter devices are commissioned over BLE before they join Thread; the
+  # matter-server pod drives hci0 directly over the system D-Bus
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+  };
+
   networking.hostName = meta.hostname; # Define your hostname.
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.


### PR DESCRIPTION
First of two changes to let the Matter Server commission devices itself, removing the phone from the loop.

## Why

Matter devices are commissioned over **BLE** before they ever join Thread. Commissioning from iOS is currently impossible:

- The iPhone holds two Thread credentials: `OpenThread-0274` (ours) and `MyHome1368903547` (Apple's).
- An mDNS scan of the LAN finds **exactly one** border router: `SLZB-MR5U._meshcop._udp.local.` advertising `OpenThread-0274` at `192.168.178.12`. There is no Apple border router.
- So `MyHome1368903547` points at a network that does not exist, iOS cannot resolve which network to use, and the commissioning request never reaches Home Assistant or the Matter Server. Confirmed across three lamps: the Matter Server log stayed completely silent.
- The stale Apple credential cannot be deleted from the phone; the HA companion app can write to the Apple Keychain but not remove Apple's own entries.

## What this does

Enables `bluetoothd`. The host already has the `hci0` adapter and `/run/dbus/system_bus_socket`, but the service was never enabled, so there is no BLE commissioner available anywhere.

`powerOnBoot` so the adapter is up after a restart without manual intervention.

## Verified

- `nix-instantiate --parse` passes.
- No pending NixOS switch: `/run/booted-system` and `/run/current-system` both resolve to `nixos-system-homelab-0-26.11.20260705.d407951`, so the old dbus-broker inhibitor is gone and this will activate cleanly.
- Pushing to main triggers the `nixos rebuild` workflow automatically via the `nixos/**` path filter.

## Next

A follow-up PR gives the matter-server pod `NET_ADMIN`/`NET_RAW`, mounts `/run/dbus`, and passes `--bluetooth-adapter 0`. Deliberately separate so we can confirm `bluetoothd` comes up before changing the manifest.

Worth knowing: once this works, the commissioning radio is the **server's**, so bulbs need to be within roughly 10m of it to be commissioned, then moved to their final socket.