### PR TITLE
feat(matter-server): commission Matter devices over the host bluetooth adapter

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -53,6 +53,14 @@ spec:
             # over IPv6 link-local, so it has to be pinned to the LAN interface
             - --primary-interface
             - enp1s0
+            # Matter devices are commissioned over BLE before they join Thread
+            - --bluetooth-adapter
+            - "0"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
           ports:
             - containerPort: 5580
               name: ws
@@ -69,7 +77,15 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            # BlueZ is driven over the host's system D-Bus
+            - name: dbus
+              mountPath: /run/dbus
+              readOnly: true
       volumes:
+        - name: dbus
+          hostPath:
+            path: /run/dbus
+            type: Directory
         - name: data
           persistentVolumeClaim:
             claimName: matter-server-data


### PR DESCRIPTION
Second of two changes to take the phone out of Matter commissioning.

**Merge #476 first and confirm `bluetoothd` is active.** Without it this pod will start but find no adapter.

## Why

Commissioning from iOS cannot work here. The iPhone holds a stale `MyHome1368903547` Apple Thread credential for a network with no border router (an mDNS scan finds only the SLZB advertising `OpenThread-0274`), it cannot be deleted from the phone, and the commissioning request never reaches the Matter Server. Verified silent across three lamps.

Giving the server its own BLE commissioner removes iOS from the path entirely, for these bulbs and every future Matter device.

## Changes

- `--bluetooth-adapter 0` to use `hci0`.
- `NET_ADMIN` / `NET_RAW`, required for HCI access.
- Mounts the host `/run/dbus` read-only, which is how BlueZ is driven. `type: Directory` so kubelet fails loudly rather than creating a placeholder, same reasoning as the ConBee `CharDevice` guard.

## Verified

- Renders through the outer app-of-apps chart.
- Passes `kubectl apply --dry-run=server`.
- Host has `hci0` and `/run/dbus/system_bus_socket` already; only the service was missing.

## Operational notes

**Commissioning range becomes the server's.** BLE reaches roughly 10m, so each bulb has to be near the server to be commissioned, then moved to its final socket. Once commissioned it joins Thread and range is governed by the SLZB instead.

**Bluetooth contention.** Home Assistant's own Bluetooth integration currently fails with `Missing NET_ADMIN/NET_RAW capabilities`, so nothing else is using `hci0` today. If HA's Bluetooth is ever fixed, the two will contend for the adapter and will need separate adapters or a decision about which owns it.