### PR TITLE
revert: back out bluetooth BLE commissioning for Matter

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -53,14 +53,6 @@ spec:
             # over IPv6 link-local, so it has to be pinned to the LAN interface
             - --primary-interface
             - enp1s0
-            # Matter devices are commissioned over BLE before they join Thread
-            - --bluetooth-adapter
-            - "0"
-          securityContext:
-            capabilities:
-              add:
-                - NET_ADMIN
-                - NET_RAW
           ports:
             - containerPort: 5580
               name: ws
@@ -77,15 +69,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            # BlueZ is driven over the host's system D-Bus
-            - name: dbus
-              mountPath: /run/dbus
-              readOnly: true
       volumes:
-        - name: dbus
-          hostPath:
-            path: /run/dbus
-            type: Directory
         - name: data
           persistentVolumeClaim:
             claimName: matter-server-data

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -39,13 +39,6 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  # Matter devices are commissioned over BLE before they join Thread; the
-  # matter-server pod drives hci0 directly over the system D-Bus
-  hardware.bluetooth = {
-    enable = true;
-    powerOnBoot = true;
-  };
-
   networking.hostName = meta.hostname; # Define your hostname.
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.


### PR DESCRIPTION
Reverts #476 (host bluetooth) and #477 (matter-server BLE).

## Why

The BLE path worked mechanically. Everything we added did what it was supposed to:

- `bluetoothd` active, adapter powered
- `NET_ADMIN` / `NET_RAW` present in the container (`CapEff 0xa80435fb`)
- `/run/dbus` mounted and reachable
- Commissioning requests reached the Matter Server for the first time (`Starting Matter commissioning with code using Node ID 1/2/3`)

It failed on **physics, not configuration**. The bulb advertises correctly as a commissionable Matter device:

```
UUID: Matter Profile ID (0000fff6-...)
ServiceData: 00 00 0f f1 ff 05 80 00
RSSI: -75 to -78 dBm
```

but -75 dBm is too weak to hold the GATT connection commissioning requires. Every attempt ended in `Discovery timed out` after 30 seconds. Seeing an advertisement at that level is easy; connecting is not.

Since commissioning range is now the server's rather than the phone's, and the fix is lamp placement plus relocating the SLZB-MR5U, there is no reason to keep a bluetooth service and elevated pod capabilities enabled but unused.

## Kept

`--primary-interface enp1s0` from #475 stays. It is unrelated to BLE and still needed so the SDK can handle IPv6 link-local addresses.

## Verified

- `nix-instantiate --parse` passes.
- Renders through the outer app-of-apps chart; passes `kubectl apply --dry-run=server`.
- Confirmed the rendered manifest still carries `--primary-interface enp1s0` and no longer has `--bluetooth-adapter`, the capabilities, or the D-Bus mount.

## Note for later

If BLE commissioning is revisited, both commits revert cleanly back in. Worth remembering that the bulb advertises vendor ID `0xFFF1` (Matter's test vendor) and discriminator 3840, so attestation may be the next hurdle after discovery, and `--enable-test-net-dcl` would be the lever.