### PR TITLE
feat(matter-server): migrate from archived python-matter-server to matterjs-server

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -41,22 +41,26 @@ spec:
       # websocket on the node, so Home Assistant (also hostNetwork) reaches it on localhost.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      # Unlike the Python server this image runs unprivileged as 1000:1000, so the
+      # existing root-owned volume has to be handed over
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: matter-server
-          image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+          image: ghcr.io/matter-js/matterjs-server:1.4.0
           imagePullPolicy: IfNotPresent
-          args:
-            - --storage-path
-            - /data
-            # Without this the SDK logs "Using 'None' as primary interface" and every
-            # mDNS advertisement fails with "No endpoint"; Thread devices are reached
-            # over IPv6 link-local, so it has to be pinned to the LAN interface
-            - --primary-interface
-            - enp1s0
           ports:
             - containerPort: 5580
               name: ws
           env:
+            - name: STORAGE_PATH
+              value: /data
+            # Thread devices are reached over IPv6 link-local; without a primary
+            # interface the SDK picks none and every mDNS advertisement fails
+            - name: PRIMARY_INTERFACE
+              value: enp1s0
             - name: TZ
               value: Europe/Amsterdam
           resources:


### PR DESCRIPTION
Moves off the deprecated Matter server I deployed in #470.

## Why

`python-matter-server` is **archived upstream** (`archived=true`, last push 2026-06-23) and receives no further updates or support. Home Assistant rewrote it in TypeScript as [`matterjs-server`](https://github.com/matter-js/matterjs-server), built on matter.js, which exposes the same WebSocket API and is documented as a drop-in replacement.

Corroborating: HA's matter integration requires `matter-python-client==1.3.0`, and that `1.x` line tracks matterjs-server's versioning, not python-matter-server's `8.x`.

I should have checked maintenance status in #470 rather than only the release list.

## Changes

| | Before | After |
|---|---|---|
| Image | `home-assistant-libs/python-matter-server:8.1.0` | `matter-js/matterjs-server:1.4.0` |
| Config | CLI args | env vars (`STORAGE_PATH`, `PRIMARY_INTERFACE`) |
| Runs as | root | **1000:1000 unprivileged** |

The security context is required, not cosmetic: the new image runs unprivileged, and upstream calls out that the data dir must be owned by `1000:1000`. `fsGroup` hands over the existing root-owned Longhorn volume.

Pinned to `1.4.0`, the current stable, rather than `stable`/`latest` so Renovate can track it.

## Verified

- Renders through the outer app-of-apps chart.
- Passes `kubectl apply --dry-run=server`.
- Image tags `1.4.0`, `1.4`, `latest`, `stable` all confirmed pullable from ghcr.
- Storage path, port 5580, and env var names taken from upstream's docker docs, not assumed.

## Risk

Upstream labels this **Beta** and notes it is not yet CSA re-certified. That is a real caveat, but the trade is favourable here: the alternative is an archived, unmaintained server, and we have **zero commissioned nodes**, so there is no fabric state to lose. First start performs a data migration; with 0 nodes there is nothing to migrate.

## Follow-up: this may fix commissioning

The new server supports `BLE_PROXY`, which exposes a `/ble` WebSocket endpoint for a **remote** BLE proxy client. That pairs with the `matter-ble-proxy==0.7.1` requirement already in HA's manifest, meaning Bluetooth for commissioning can come from Home Assistant rather than the server's own adapter.

That directly addresses the constraint that killed the earlier attempt (#476/#477, reverted in #478), where the bulb had to be within ~10m of the server and sat at -75 dBm. With a BLE proxy, coverage can be placed near the lamps instead.

Deliberately **not** enabled here to keep this a like-for-like migration. Note it still needs a working Bluetooth source on the HA side, which currently fails with `Missing NET_ADMIN/NET_RAW capabilities`, so an ESPHome Bluetooth proxy near the lamps is likely the cleanest option.