### PR TITLE
fix(home-assistant): remove ConBee hostPath now the dongle is gone

### DIFF
--- a/apps/templates/helm-homeassistant.yaml
+++ b/apps/templates/helm-homeassistant.yaml
@@ -47,16 +47,6 @@ spec:
         hostNetwork: true
         securityContext:
           privileged: true
-        additionalVolumes:
-          - name: conbee-usb
-            hostPath:
-              path: /dev/ttyACM0
-              # Without this kubelet creates a placeholder directory when the dongle
-              # is unplugged, which shadows the real device node and breaks Zigbee
-              type: CharDevice
-        additionalMounts:
-          - name: conbee-usb
-            mountPath: /dev/ttyACM0
   destination:
     namespace: home-assistant
     server: https://kubernetes.default.svc


### PR DESCRIPTION
**Home Assistant is currently down.** The pod is stuck in `Init:0/1` and cannot start.

```
MountVolume.SetUp failed for volume "conbee-usb":
  hostPath type check failed: /dev/ttyACM0 is not a character device
```

## Cause

The ConBee II has been physically removed in favour of the SLZB-MR5U. Verified on the host:

- `/dev/ttyACM0` — no such file or directory
- USB bus shows only the Intel bluetooth controller and the two xHCI hubs; no dresden elektronik device

The `type: CharDevice` guard from 54a0e2a is behaving exactly as intended: refusing to start rather than letting kubelet create a placeholder directory that would shadow the real node. But the mount it guards no longer has anything behind it, so it is now just blocking startup.

ZHA has pointed at `socket://192.168.178.12:6638` since the SLZB migration, so nothing consumes the USB passthrough.

## Change

Removes `additionalVolumes` and `additionalMounts` for `conbee-usb`. No other values touched.

## Verified

- `grep` for `conbee|ttyACM` returns **0** matches both in the outer app-of-apps render and in the rendered StatefulSet from the upstream chart.
- Renders cleanly through the outer chart.

This is the follow-up I flagged when adding the guard: once ZHA moved to TCP the mount became unnecessary, and leaving it in place turned an unplugged dongle into a startup failure.