### PR TITLE
feat(matter-server): enable BLE proxy for commissioning

### DIFF
--- a/apps/templates/app-matter-server.yaml
+++ b/apps/templates/app-matter-server.yaml
@@ -61,6 +61,11 @@ spec:
             # interface the SDK picks none and every mDNS advertisement fails
             - name: PRIMARY_INTERFACE
               value: enp1s0
+            # Exposes the /ble endpoint that Home Assistant's matter-ble-proxy drives, so
+            # commissioning uses HA's bluetooth (an ESPHome proxy near the lamps) instead
+            # of an adapter on this host. Mutually exclusive with BLUETOOTH_ADAPTER.
+            - name: BLE_PROXY
+              value: "true"
             - name: TZ
               value: Europe/Amsterdam
           resources:


### PR DESCRIPTION
Enables the server side of BLE commissioning so the E27 806lm KAJPLATS bulbs can be onboarded.

## Why

The 806lm bulbs will not pair. Evidence:

- **Thread mesh has exactly 4 nodes**: the border router plus the three 470lm bulbs, all routers. No 806lm bulb has ever joined.
- **The Matter server log records zero failed commissioning attempts** — only two discoveries, both successful. The 806lm attempts never reach the server.

The 470lm bulbs are not evidence that commissioning works. Every successful one logged:

```
Skipping NetworkCommissioning steps because the device is already on IP network (udp)
```

They were already on Thread from earlier phone attempts, so the server only had to complete the handshake. A fresh bulb needs the BLE onboarding step, and the server has no adapter since #478.

## What this does

`BLE_PROXY=true` exposes the `/ble` WebSocket endpoint that HA's `matter-ble-proxy` connects to. Bluetooth then comes from Home Assistant rather than this host, which means it can come from an **ESPHome Bluetooth proxy near the lamps** rather than requiring the bulb within ~10m of the server — the constraint that killed the earlier attempt.

No Home Assistant configuration is required. From `homeassistant/components/matter/__init__.py`:

```python
# Gate on `ble_proxy_enabled`, not `bluetooth_enabled`: the latter is also true
# when the server uses a local BLE adapter, where no `/ble` endpoint exists.
if server_info and server_info.ble_proxy_enabled:
    ble_proxy_url = _derive_ble_proxy_url(entry.data[CONF_URL])
    ble_proxy = create_matter_ble_proxy(hass, ble_proxy_url)
    await ble_proxy.connect()
```

HA reads the flag from the server and derives the URL itself.

## Verified

- Renders through the outer app-of-apps chart; passes `kubectl apply --dry-run=server`.
- `BLUETOOTH_ADAPTER` is not set anywhere (0 occurrences as an env var), so there is no conflict with the mutually exclusive option.

## Required on the device side

This PR alone is not sufficient. The SLZB-MR5U needs its **Bluetooth Proxy (ESPHome based)** mode enabled, and HA needs the ESPHome integration for it — HA currently has no `esphome` config entry.

The proxy must support **active connections**, not just passive scanning. Matter commissioning establishes a GATT connection, so a scan-only proxy will find the bulb and then fail.