### PR TITLE
feat(nixos): enable bluetooth so Home Assistant can drive the Matter BLE proxy

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -39,6 +39,13 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Matter devices are onboarded over BLE before they join Thread. Home Assistant
+  # drives hci0 and relays it to the Matter server's /ble proxy endpoint.
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+  };
+
   networking.hostName = meta.hostname; # Define your hostname.
   # Pick only one of the below networking options.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.


### PR DESCRIPTION
Restores host bluetooth so the E27 806lm KAJPLATS bulbs can be onboarded.

## Why

There is currently **no bluetooth source anywhere in the stack**:

```
SLZB port 6053:      closed   (no ESPHome proxy)
host bluetoothd:     inactive (removed in #478)
hci0:                present
HA bluetooth entry:  disabled_by: user
```

The Matter server's BLE proxy is already up and Home Assistant is connected to it:

```
BleProxyHandler     BLE proxy WebSocket endpoint registered on /ble
BleProxyConnection  [ble0] BLE proxy handshake complete (version 1)
```

but there is no radio behind it.

The SLZB route is a dead end: its "Bluetooth Proxy (ESPHome based)" button links to instructions for **reflashing the device with ESPHome firmware**, which would replace SLZB-OS and cost us both the Zigbee coordinator and the Thread border router. Not worth it for a commissioning step.

## Why this is not just a revert of #478

In #476/#477 the **Matter server** held the adapter directly, so the bulb had to be near the server and it failed at -75 dBm. With `BLE_PROXY` from #481, **Home Assistant owns the radio** and relays it over `/ble`. The radio is only needed during onboarding; once a bulb joins Thread it is reached through the mesh, which now has three router nodes.

So the range constraint becomes a one-time "carry the bulb to the server" rather than a permanent placement problem.

## Verified

- `nix-instantiate --parse` passes.
- `hci0` present on the host; only the service is missing.
- No pending NixOS switch, so this will activate cleanly.
- Pushing to main triggers the `nixos rebuild` workflow via the `nixos/**` path filter.

## Manual step after merge

Home Assistant's bluetooth config entry is currently `disabled_by: user` and must be re-enabled in the UI, otherwise HA will have the adapter available but ignore it.

Note HA logs `Missing NET_ADMIN/NET_RAW capabilities` for bluetooth. That message is specifically about *automatic adapter recovery*, not basic operation, so scanning and connecting should work without granting them. If commissioning fails in a way that points at the adapter, that is the next lever.