### PR TITLE
fix(home-assistant): mount host D-Bus so the bluetooth integration can reach BlueZ

### DIFF
--- a/apps/templates/helm-homeassistant.yaml
+++ b/apps/templates/helm-homeassistant.yaml
@@ -47,6 +47,17 @@ spec:
         hostNetwork: true
         securityContext:
           privileged: true
+        additionalVolumes:
+          # BlueZ is driven over the host system bus; without this the bluetooth
+          # integration fails with "DBus service not found"
+          - name: dbus
+            hostPath:
+              path: /run/dbus
+              type: Directory
+        additionalMounts:
+          - name: dbus
+            mountPath: /run/dbus
+            readOnly: true
   destination:
     namespace: home-assistant
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Last piece of the Matter BLE commissioning chain.

## Problem

`bluetoothd` is now active on the host (#482) and the adapter is powered, but Home Assistant still cannot use it:

```
Failed setup, will retry: hci0 (0C:54:15:79:C4:89): DBus service not found;
make sure the DBus socket is available: [Errno 2] No such file or directory
```

BlueZ is controlled over the **system D-Bus**, and the HA pod has no `/run/dbus`. Confirmed:

- host: `srw-rw-rw- /run/dbus/system_bus_socket` exists
- pod: `ls: /run/dbus: No such file or directory`, volumes are only `home-assistant`, `init-volume`, `config-volume`, `kube-api-access`

**Capabilities are not the issue.** `privileged: true` already grants the full set (`CapEff 000001ffffffffff`), so the `Missing NET_ADMIN/NET_RAW` line that has been in the log for weeks is a red herring for this failure.

## Change

Mounts the host `/run/dbus` read-only via the chart's `additionalVolumes`/`additionalMounts`. `type: Directory` so kubelet fails loudly rather than silently creating a placeholder — same reasoning as the ConBee `CharDevice` guard, and this time the path is a permanent host directory rather than a removable dongle, so it cannot become the startup trap that one did.

## Verified

- Renders through the outer app-of-apps chart.
- Rendered StatefulSet carries both the `dbus` volume (`hostPath: /run/dbus`, `type: Directory`) and the read-only `/run/dbus` mount.

## Chain status after this

```
bluetoothd active + adapter powered      ✅ (#482)
HA has D-Bus to reach BlueZ              ← this PR
HA bluetooth config entry enabled        ⚠️ manual, currently disabled_by: user
Matter server BLE_PROXY /ble endpoint    ✅ (#481, handshake seen)
```

Home Assistant's bluetooth entry still has to be re-enabled in the UI after this merges.